### PR TITLE
Fix: A1-1

### DIFF
--- a/app/routes/contributions.js
+++ b/app/routes/contributions.js
@@ -29,16 +29,15 @@ function ContributionsHandler(db) {
 
         /*jslint evil: true */
         // Insecure use of eval() to parse inputs
-        const preTax = eval(req.body.preTax);
-        const afterTax = eval(req.body.afterTax);
-        const roth = eval(req.body.roth);
+        // const preTax = eval(req.body.preTax);
+        // const afterTax = eval(req.body.afterTax);
+        // const roth = eval(req.body.roth);
 
-        /*
         //Fix for A1 -1 SSJS Injection attacks - uses alternate method to eval
         const preTax = parseInt(req.body.preTax);
         const afterTax = parseInt(req.body.afterTax);
         const roth = parseInt(req.body.roth);
-        */
+
         const {
             userId
         } = req.session;


### PR DESCRIPTION
- Remove all eval functions in converting the user inputs
- Convert eval to parseInt

Down the server
![A1-1 Attack](https://github.com/maytlead/NodeGoat/assets/148783274/c4c3cc4a-a7da-40d0-8f95-1ef50fa0ef8c)
![A1-1 Result 1](https://github.com/maytlead/NodeGoat/assets/148783274/71b5597b-41f5-48da-a7f1-d65a02adafd7)
![A1-1 Result 2](https://github.com/maytlead/NodeGoat/assets/148783274/a4d2b828-fe9f-4b89-8c7c-31b7e2eb74db)

Read file system
![A1 Read File System Attack 1](https://github.com/maytlead/NodeGoat/assets/148783274/4675e626-4b28-4a6f-91c5-1ae3b8941cf8)
![A1 Read File System Fix 1](https://github.com/maytlead/NodeGoat/assets/148783274/c9708699-5aa9-4115-a487-3ce3d1c46710)

Read specific file
![A1 Read File System Attack 2](https://github.com/maytlead/NodeGoat/assets/148783274/d752a4ea-5dec-4d15-903e-7fd341a6ebab)
![A1 Read File System Fix 2](https://github.com/maytlead/NodeGoat/assets/148783274/16269ad1-0ba6-4f51-9b1a-280ae48c1a5e)

After Fix
![A1-1 Fix](https://github.com/maytlead/NodeGoat/assets/148783274/af9456ad-c06e-42d9-b6a5-7507699d6b69)
