### PR TITLE
Fix: A1-3

### DIFF
--- a/app/routes/session.js
+++ b/app/routes/session.js
@@ -61,18 +61,18 @@ function SessionHandler(db) {
             const invalidPasswordErrorMessage = "Invalid password";
             if (err) {
                 if (err.noSuchUser) {
-                    console.log("Error: attempt to login with invalid user: ", userName);
+                    // console.log("Error: attempt to login with invalid user: ", userName);
 
                     // Fix for A1 - 3 Log Injection - encode/sanitize input for CRLF Injection
                     // that could result in log forging:
                     // - Step 1: Require a module that supports encoding
-                    // const ESAPI = require('node-esapi');
+                    const ESAPI = require('node-esapi');
                     // - Step 2: Encode the user input that will be logged in the correct context
                     // following are a few examples:
                     // console.log('Error: attempt to login with invalid user: %s',
                     //     ESAPI.encoder().encodeForHTML(userName));
-                    // console.log('Error: attempt to login with invalid user: %s',
-                    //     ESAPI.encoder().encodeForJavaScript(userName));
+                    console.log('Error: attempt to login with invalid user: %s',
+                        ESAPI.encoder().encodeForJavaScript(userName));
                     // console.log('Error: attempt to login with invalid user: %s',
                     //     ESAPI.encoder().encodeForURL(userName));
                     // or if you know that this is a CRLF vulnerability you can target this specifically as follows:


### PR DESCRIPTION
- Remove direct use user input in logging
- Log out the encoded logging context

Before Fix
![A1-3 Attack](https://github.com/maytlead/NodeGoat/assets/148783274/b8fe9d85-74af-4d96-b7bc-6b431e9a22d8)
![A1-3 Result](https://github.com/maytlead/NodeGoat/assets/148783274/90eb3269-03f0-4553-b4d1-0529f3bf8810)

After Fix
![A1-3 Fix](https://github.com/maytlead/NodeGoat/assets/148783274/6d730b26-5d4a-4b75-88c4-15a79258fc7c)
