### PR TITLE
Fix: A3 XSS Attack

### DIFF
--- a/server.js
+++ b/server.js
@@ -9,13 +9,13 @@ const consolidate = require("consolidate"); // Templating library adapter for Ex
 const swig = require("swig");
 // const helmet = require("helmet");
 const MongoClient = require("mongodb").MongoClient; // Driver for connecting to MongoDB
-const http = require("http");
+// const http = require("http");
 const marked = require("marked");
 //const nosniff = require('dont-sniff-mimetype');
 const app = express(); // Web framework to handle routing requests
 const routes = require("./app/routes");
 const { port, db, cookieSecret } = require("./config/config"); // Application config properties
-/*
+
 // Fix for A6-Sensitive Data Exposure
 // Load keys for establishing secure HTTPS connection
 const fs = require("fs");
@@ -25,7 +25,6 @@ const httpsOptions = {
     key: fs.readFileSync(path.resolve(__dirname, "./artifacts/cert/server.key")),
     cert: fs.readFileSync(path.resolve(__dirname, "./artifacts/cert/server.crt"))
 };
-*/
 
 MongoClient.connect(db, (err, db) => {
     if (err) {
@@ -140,16 +139,14 @@ MongoClient.connect(db, (err, db) => {
     });
 
     // Insecure HTTP connection
-    http.createServer(app).listen(port, () => {
-        console.log(`Express http server listening on port ${port}`);
-    });
+    // http.createServer(app).listen(port, () => {
+    //     console.log(`Express http server listening on port ${port}`);
+    // });
 
-    /*
     // Fix for A6-Sensitive Data Exposure
     // Use secure HTTPS protocol
     https.createServer(httpsOptions, app).listen(port, () => {
         console.log(`Express http server listening on port ${port}`);
     });
-    */
 
 });

--- a/server.js
+++ b/server.js
@@ -82,22 +82,20 @@ MongoClient.connect(db, (err, db) => {
         secret: cookieSecret,
         // Both mandatory in Express v4
         saveUninitialized: true,
-        resave: true
+        resave: true,
         /*
         // Fix for A5 - Security MisConfig
         // Use generic cookie name
         key: "sessionId",
         */
 
-        /*
         // Fix for A3 - XSS
         // TODO: Add "maxAge"
         cookie: {
-            httpOnly: true
+            httpOnly: true,
             // Remember to start an HTTPS server to get this working
-            // secure: true
+            secure: true
         }
-        */
 
     }));
 

--- a/server.js
+++ b/server.js
@@ -131,11 +131,9 @@ MongoClient.connect(db, (err, db) => {
     // Template system setup
     swig.setDefaults({
         // Autoescape disabled
-        autoescape: false
-        /*
+        // autoescape: false
         // Fix for A3 - XSS, enable auto escaping
         autoescape: true // default value
-        */
     });
 
     // Insecure HTTP connection


### PR DESCRIPTION
- Make cookie only accessible via http to prevent XSS attack
- Run the server as https
- Enable autoescape for XSS

Before Fix
![A3 XSS Attack](https://github.com/maytlead/NodeGoat/assets/148783274/92cbc230-3d5c-4917-85ec-9164ad471eb7)
![A3 XSS Attack Result](https://github.com/maytlead/NodeGoat/assets/148783274/e27346be-387d-43db-894f-4478f24478bf)

After Fix
![A3 XSS Attack Fix](https://github.com/maytlead/NodeGoat/assets/148783274/755d9d2f-1ed7-4b27-b13b-fab4a999680f)
