### PR TITLE
Fix: A4 IDOR Attack

### DIFF
--- a/app/routes/allocations.js
+++ b/app/routes/allocations.js
@@ -9,13 +9,11 @@ function AllocationsHandler(db) {
     const allocationsDAO = new AllocationsDAO(db);
 
     this.displayAllocations = (req, res, next) => {
-        /*
         // Fix for A4 Insecure DOR -  take user id from session instead of from URL param
         const { userId } = req.session;
-        */
-        const {
-            userId
-        } = req.params;
+        // const {
+        //     userId
+        // } = req.params;
         const {
             threshold
         } = req.query;


### PR DESCRIPTION
- Use userId from session, instead of getting userId from url params

Before Fix
![A4 IDOR Attack 1](https://github.com/maytlead/NodeGoat/assets/148783274/0eaac865-b169-42fe-b1e9-90a84ce76463)
![A4 IDOR Attack 2](https://github.com/maytlead/NodeGoat/assets/148783274/8dce29a2-ff8c-45ad-91ea-436520d44417)
![A4 IDOR Result](https://github.com/maytlead/NodeGoat/assets/148783274/9e510787-5b38-4f5a-9baa-d2faacd76b24)

After Fix
![A4 IDOR Fix](https://github.com/maytlead/NodeGoat/assets/148783274/93398eeb-da82-4fe9-9df6-92061f61f5b9)
