### PR TITLE
Fix: A8 CSRF Attack

### DIFF
--- a/app/views/contributions.html
+++ b/app/views/contributions.html
@@ -87,9 +87,7 @@
                             </tbody>
                         </table>
                         <!-- Fix for A8 - CSRF -->
-                        <!--
                         <input type="hidden" name="_csrf" value="{{csrftoken}}"></input>
-                        -->
                         <button type="submit" class="btn btn-default">Submit</button>
 
                     </form>

--- a/server.js
+++ b/server.js
@@ -98,7 +98,6 @@ MongoClient.connect(db, (err, db) => {
 
     }));
 
-    /*
     // Fix for A8 - CSRF
     // Enable Express csrf protection
     app.use(csrf());
@@ -107,7 +106,6 @@ MongoClient.connect(db, (err, db) => {
         res.locals.csrftoken = req.csrfToken();
         next();
     });
-    */
 
     // Register templating engine
     app.engine(".html", consolidate.swig);


### PR DESCRIPTION
- Add csrf token on the frontend
- Add csrftoken middleware on the backend

Before Fix
![A8 CSRF Attack 1](https://github.com/maytlead/NodeGoat/assets/148783274/2769a425-94d2-445f-90a7-ac22fe35e0ba)
![A8 CSRF Attack 2](https://github.com/maytlead/NodeGoat/assets/148783274/8f71754f-391f-4082-b178-dc88b5eeec89)
![A8 CSRF Attack 3](https://github.com/maytlead/NodeGoat/assets/148783274/b689e3b0-8950-4a47-bac2-8d26544c58c2)

After Fix
![A8 CSRF Attack Fix](https://github.com/maytlead/NodeGoat/assets/148783274/473d7fae-d39a-439f-ba76-eafd56a3c74e)
