### PR TITLE
Fix:A10 Redirects

### DIFF
--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -7,6 +7,7 @@ const MemosHandler = require("./memos");
 const ResearchHandler = require("./research");
 const tutorialRouter = require("./tutorial");
 const ErrorHandler = require("./error").errorHandler;
+const LearnResource = require("./learn");
 
 const index = (app, db) => {
 
@@ -69,7 +70,7 @@ const index = (app, db) => {
     // Handle redirect for learning resources link
     app.get("/learn", isLoggedIn, (req, res) => {
         // Insecure way to handle redirects by taking redirect url from query string
-        return res.redirect(req.query.url);
+        return res.redirect(LearnResource[req.query.url] ? LearnResource[req.query.url] : "/");
     });
 
     // Research Page

--- a/app/routes/learn.js
+++ b/app/routes/learn.js
@@ -1,0 +1,6 @@
+const LearnResource = {
+  learn_resource_1:
+    "https://www.khanacademy.org/economics-finance-domain/core-finance/investment-vehicles-tutorial/ira-401ks/v/traditional-iras",
+};
+
+module.exports = LearnResource;

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -59,7 +59,7 @@
                     </li>
                     <li><a id="profile-menu-link" href="/profile"><i class="fa fa-user"></i> Profile</a>
                     </li>
-                    <li><a id="learn-menu-link" target="_blank" href="/learn?url=https://www.khanacademy.org/economics-finance-domain/core-finance/investment-vehicles-tutorial/ira-401ks/v/traditional-iras"><i class="fa fa-edit"></i> Learning Resources</a>
+                    <li><a id="learn-menu-link" target="_blank" href="/learn?url=learn_resource_1"><i class="fa fa-edit"></i> Learning Resources</a>
                     </li>
                     <li><a id="research-menu-link" href="/research"><i class="fa fa-table"></i> Research</a>
                     </li>


### PR DESCRIPTION
- Use learn resource id and map the id to actual url on the backend

Before Fix
![A10 Redirects Attack](https://github.com/maytlead/NodeGoat/assets/148783274/24682d84-da3f-425f-9ee6-6bae43d2acab)
![A10 Redirects Result](https://github.com/maytlead/NodeGoat/assets/148783274/5980434e-1e31-4766-9352-5c5e38f54605)

After Fix
![A10 Redirects Fix 1](https://github.com/maytlead/NodeGoat/assets/148783274/af8d406b-7da2-4e9c-b129-c9baaf8fffed)
![A10 Redirects Fix 2](https://github.com/maytlead/NodeGoat/assets/148783274/f1b1dd7b-83fc-4d63-90ea-01926b75d1f6)
![A10 Redirects Fix 3](https://github.com/maytlead/NodeGoat/assets/148783274/0c58763e-42de-4784-9073-a89f68f59230)
![A10 Redirects Fix 4](https://github.com/maytlead/NodeGoat/assets/148783274/5eb4cfa5-0320-40ef-aad2-e4422cd85318)
